### PR TITLE
Add the current koa context to templateOptions.data to provide access within helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,6 +184,14 @@ Hbs.prototype.createRenderer = function() {
     template = hbs.cache[tpl].template;
     layoutTemplate = hbs.cache[tpl].layoutTemplate || hbs.layoutTemplate;
 
+    // Add the current koa context to templateOptions.data to provide access
+    // to the request within helpers.
+    if (!hbs.templateOptions.data) {
+      hbs.templateOptions.data = {};
+    }
+
+    hbs.templateOptions.data = merge(hbs.templateOptions.data, { koa: this });
+
     // Run the compiled templates
     locals.body = template(locals, hbs.templateOptions);
     this.body = layoutTemplate(locals, hbs.templateOptions);


### PR DESCRIPTION
We had a specific need to access the current koa request context within nearly all of our helpers. This provides useful access to that information within custom helpers.

I'm open to other naming options other than `data.koa` but it seemed most appropriate given that `context` has a different meaning in handlebars, once you're in that land.
