### PR TITLE
Update docs, don't advise using --harmony or harmonica anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Koa v2 or higher. This branch will not work with Koa v1.x.
 
 This branch assumes native `async/await` support. Node v7.6 and newer support `async/await`
 without the use of flags. For Node versions between v7.0 and v7.6, the `--harmony-async-await`
-flag is required to active native support. We recommend using
+flag is required to active native support. It's best to update the Node version used to v7.6 or newer as that's the most stable setup that doesn't require using any experimental flags. If that's not possible we recommend using
 [harmonica](https://www.npmjs.com/package/harmonica) to enable the `--harmony`
 flags programmatically. An example pattern for using `harmonica` can be found in
 this branch within [gulpfile.js](gulpfile.js).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,5 @@
 'use strict';
 
-require('harmonica')();
-
 const eslint = require('gulp-eslint');
 const gulp = require('gulp');
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "gulp": "^3.9.1",
     "gulp-eslint": "^3.0.1",
     "gulp-mocha": "^4.3.1",
-    "harmonica": "^1.2.2",
     "koa": "^2.2.0",
     "koa-router": "^7.2.0",
     "supertest": "^3.0.0"


### PR DESCRIPTION
Node.js 7.6.0 and newer support async/await natively and older versions
have serious memory leaks so it's better to not rely on --harmony. If running
Koa in an older Node.js version is desired, it's better to transpile async/await
rather than rely on a buggy implementation.