### PR TITLE
upgrade dependencies and fix peerDependencies warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,22 +30,22 @@
   },
   "license": "MIT",
   "dependencies": {
-    "glob": "^7.0.5",
-    "handlebars": "^4.0.5"
+    "glob": "^7.1.1",
+    "handlebars": "^4.0.8"
   },
   "devDependencies": {
     "co": "^4.6.0",
-    "eslint": "^3.12.2",
+    "eslint": "^3.19.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^3.0.1",
-    "gulp-mocha": "^3.0.1",
-    "harmonica": "^1.2.1",
-    "koa": "~2.0.0-alpha.7",
-    "koa-router": "^7.1.0",
-    "supertest": "^2.0.1"
+    "gulp-mocha": "^4.3.1",
+    "harmonica": "^1.2.2",
+    "koa": "^2.2.0",
+    "koa-router": "^7.1.1",
+    "supertest": "^3.0.0"
   },
   "peerDependencies": {
-    "koa": "~2.0.0-alpha.7"
+    "koa": "^2.0.0"
   },
   "engines": {
     "node": ">= 7.0.0"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "glob": "^7.1.1",
-    "handlebars": "^4.0.8"
+    "glob": "^7.1.2",
+    "handlebars": "^4.0.10"
   },
   "devDependencies": {
     "co": "^4.6.0",
@@ -41,7 +41,7 @@
     "gulp-mocha": "^4.3.1",
     "harmonica": "^1.2.2",
     "koa": "^2.2.0",
-    "koa-router": "^7.1.1",
+    "koa-router": "^7.2.0",
     "supertest": "^3.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
`npm WARN koa-hbs@1.0.0-alpha.1 requires a peer of koa@~2.0.0-alpha.7 but none was installed.`

Koa2 has moved out of alpha. This will silence the warning.