### PR TITLE
Overwriting partials in same behaviour as views (first match will be used)

### DIFF
--- a/index.js
+++ b/index.js
@@ -378,8 +378,11 @@ Hbs.prototype.registerPartials = function () {
       // Generate list of files and template names
       resultList.forEach((result, i) => {
         result.forEach((file) => {
-          files.push(path.join(self.partialsPath[i], file));
-          names.push(file.slice(0, -1 * self.extname.length));
+          let name = file.slice(0, -1 * self.extname.length);
+          if (names.indexOf(name) === -1) {
+            files.push(path.join(self.partialsPath[i], file));
+            names.push(name);
+          }
         });
       });
 


### PR DESCRIPTION
Same behaviour as for views: first path with found partial name will be used. If a partial with the same name is already registered, it will be ignored. Manual registration is still possible and will overwrite the partial.